### PR TITLE
fix: orchestrate env activate argument name

### DIFF
--- a/docs/labs/environment-setup-lab/wxo-client-setup.md
+++ b/docs/labs/environment-setup-lab/wxo-client-setup.md
@@ -66,7 +66,7 @@ Install the IBM watsonx Orchestrate ADK on your computer.
 
 ```
 orchestrate env add --name bootcamp --url <REPLACE_WITH_WXO_INSTANCE_URL> -t ibm_iam
-orchestrate env activate bootcamp --apikey <YOUR_API_KEY>
+orchestrate env activate bootcamp --api-key <YOUR_API_KEY>
 
 ```
 


### PR DESCRIPTION
Fixed --api-key argument, before was --apikey.